### PR TITLE
Fix warning about main queue setup override in RN 0.59

### DIFF
--- a/Example/ios/TuyaRnDemo/TuyaRNSDK/Utils/Listener/TuyaRNEventEmitter.m
+++ b/Example/ios/TuyaRnDemo/TuyaRNSDK/Utils/Listener/TuyaRNEventEmitter.m
@@ -58,6 +58,10 @@ RCT_EXPORT_MODULE()
   return self;
 }
 
++ (BOOL)requiresMainQueueSetup {
+  return YES;
+}
+
 - (void)deviceInfoNotification:(NSNotification *)notification {
   NSDictionary *body = notification.object;
   [self sendEventWithName:notification.name body:body];


### PR DESCRIPTION
In React Native 0.59 you get a warning when starting the app, like in the screenshot here:
 
![Screenshot 2019-05-22 at 14 12 34](https://user-images.githubusercontent.com/533616/58173929-ec237580-7c9c-11e9-9ab9-e5120d65ebaf.png)

This pull request removes that warning.